### PR TITLE
Create scrobble tracks job

### DIFF
--- a/app/workers/scrobble_tracks.rb
+++ b/app/workers/scrobble_tracks.rb
@@ -1,0 +1,74 @@
+class ScrobbleTracks
+  include Sidekiq::Worker
+
+  NUM_TRACKS = 5
+
+  def perform(user_id)
+    recent_tracks = current_spotify_user(user_id).recently_played(limit: NUM_TRACKS)
+
+    require 'pry'
+    binding.pry
+    get_scrobble_difference(recent_tracks, user_id).each do |track|
+      add_scrobble(user_id, track.id)
+    end
+  end
+
+  private
+
+  def get_scrobble_difference(recent_tracks, user_id)
+    saved_scrobbles = last_saved_scrobbles(user_id)
+
+    saved_tracks = tracks_from_scrobbles(saved_scrobbles)
+
+    remove_duplicates(recent_tracks, saved_tracks)
+  end
+
+  def remove_duplicates(recent_tracks, saved_tracks)
+    recent_tracks.select do |track|
+      !track_list_includes?(track, saved_tracks)
+    end
+  end
+
+  def track_list_includes?(track, track_list)
+    return_value = false
+    track_list.each do |track_from_list|
+      if track.name == track_from_list.name && track.artists.first.name == track_from_list.artists.first.name
+        return_value = true
+        break
+      end
+    end
+
+    return_value
+  end
+
+  def add_scrobble(user_id, track_id)
+    Scrobble.create(user_id: user_id, track_id: track_id)
+  end
+
+  def last_saved_scrobbles(user_id)
+    if Scrobble.where(user_id: user_id).exists?
+      scrobbles = Scrobble.where(user_id: user_id).order('created_at desc').limit(NUM_TRACKS)
+    else
+      scrobbles = []
+    end
+
+    scrobbles.select do |scrobble|
+      Time.now.utc > scrobble.created_at.utc - 20.minutes
+    end
+  end
+
+  def tracks_from_scrobbles(scrobbles)
+    track_ids = scrobbles.map do |scrobble|
+      scrobble.track_id
+    end
+    RSpotify::Track.find(track_ids)
+  end
+
+  def current_spotify_user(user_id)
+    user = SpotifyUser.find_by(user_id: user_id)
+
+    return nil unless user
+
+    RSpotify::User.new(user.spotify_user_hash)
+  end
+end

--- a/db/migrate/20191111224617_create_tracks.rb
+++ b/db/migrate/20191111224617_create_tracks.rb
@@ -1,9 +1,0 @@
-class CreateTracks < ActiveRecord::Migration[6.0]
-  def change
-    create_table :tracks do |t|
-      t.string :name
-      t.string :artist_name
-      t.jsonb :track
-    end
-  end
-end

--- a/db/migrate/20191111225310_create_scrobbles.rb
+++ b/db/migrate/20191111225310_create_scrobbles.rb
@@ -1,6 +1,8 @@
 class CreateScrobbles < ActiveRecord::Migration[6.0]
   def change
     create_table :scrobbles do |t|
+      t.string :track_id, null: false
+
       t.timestamps
     end
   end

--- a/db/migrate/20191111230606_add_foreign_keys_to_scrobbles.rb
+++ b/db/migrate/20191111230606_add_foreign_keys_to_scrobbles.rb
@@ -1,6 +1,5 @@
 class AddForeignKeysToScrobbles < ActiveRecord::Migration[6.0]
   def change
     add_reference :scrobbles, :user, null: false, foreign_key: true
-    add_reference :scrobbles, :track, null: false, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,11 +16,10 @@ ActiveRecord::Schema.define(version: 2019_11_11_230606) do
   enable_extension "plpgsql"
 
   create_table "scrobbles", force: :cascade do |t|
+    t.string "track_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
-    t.bigint "track_id", null: false
-    t.index ["track_id"], name: "index_scrobbles_on_track_id"
     t.index ["user_id"], name: "index_scrobbles_on_user_id"
   end
 
@@ -28,12 +27,6 @@ ActiveRecord::Schema.define(version: 2019_11_11_230606) do
     t.jsonb "spotify_user_hash", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_spotify_users_on_user_id"
-  end
-
-  create_table "tracks", force: :cascade do |t|
-    t.string "name"
-    t.string "artist_name"
-    t.jsonb "track"
   end
 
   create_table "users", force: :cascade do |t|
@@ -48,7 +41,6 @@ ActiveRecord::Schema.define(version: 2019_11_11_230606) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "scrobbles", "tracks"
   add_foreign_key "scrobbles", "users"
   add_foreign_key "spotify_users", "users"
 end


### PR DESCRIPTION
This is the most disgusting mess ever, please don't judge me. The
`Track` objects in RSpotify apparently can't be compared with == or
maybe I am dumb and using it wrong, but it means I have to compare
myself. I just compared song name and artist which seems fine to me, but
maybe I should just check the ID. I want to avoid double scrobbling if
there is the same song as a single and on the album so screw it.