### PR TITLE
Remove sidekiq from routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,6 @@ Rails.application.routes.draw do
   root 'home#index'
   get '/auth/spotify/callback', to: 'users#spotify'
 
-  require 'sidekiq/web'
-  mount Sidekiq::Web => '/sidekiq'
 
   resources :users
   resources :home, only: %i[index show]


### PR DESCRIPTION
This seems like a security vulnerability on prod and I don't exactly
know how to lock it down, so screw it.