### PR TITLE
Add artist inputs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,15 @@
 //= require jquery3
 
 $(document).ready(function() {
-    $(":input").each(function() {
+    track_changes();
+
+    $("#save-button").click(function () {
+       save_playlist();
+    });
+});
+
+function track_changes() {
+    $(".recommendation-input").each(function() {
         $(this).change(function() {
             if (too_many_checked()) {
                 alert("You can only select up to 5 artists");
@@ -12,11 +20,7 @@ $(document).ready(function() {
             }
         });
     });
-
-    $("#save-button").click(function () {
-       save_playlist();
-    });
-});
+}
 
 function update_recommendations() {
     $.ajax({
@@ -61,12 +65,18 @@ function track_data() {
 
 function data_from_inputs() {
     let data = {};
-    $(":input").each(function() {
+    $(".recommendation-input").each(function() {
         let input = $(this);
 
         if (input.attr('type') === 'checkbox') {
             if (input.prop('checked') === true) {
-                data[input.attr('name')] = input.attr('value')
+                if (input.attr('value') !== '') {
+                    data[input.attr('name')] = input.attr('value')
+                } else {
+                    let number = input.attr('id').slice(-1);
+                    let jquery_string = "#artist-submit-text-" + number;
+                    data['input_artist_' + number] = $(jquery_string).val()
+                }
             }
         }
 
@@ -84,6 +94,7 @@ function set_data(data) {
         let row = '<tr><td>' + track.name + '</td><td>' + track.artists.join(', ') + '</td><td>' + track.album + '</td><td hidden>' + track.id + '</td></tr>';
 
         $('#help-text').hide();
+        $('#error-text').hide();
         hide_progress_bar();
         tableBody.append(row);
     }
@@ -107,6 +118,7 @@ function show_table() {
 function handle_error(error) {
     hide_progress_bar();
     $('#help-text').show();
+    $('#error-text').show();
     $('#recommendation-table').hide();
     $('#save-button').addClass('is-hidden');
     $('#playlist-name').addClass('is-hidden');

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -15,7 +15,7 @@ class SpotifyController < ApplicationController
     @top_artists = Users::Helpers::RetrieveSpotifyUser.
         new.
         call(user_id: current_user.id)&.
-        top_artists(limit: 20, time_range: 'short_term')
+        top_artists(limit: 15, time_range: 'short_term')
 
     if params['acousticness']
       render json: formatted_recommended_tracks(RSpotify::Recommendations.generate(formatted_form_response).tracks)
@@ -66,7 +66,11 @@ class SpotifyController < ApplicationController
   def artist_list
     artists = []
     params.each do |key, value|
-      if key.include?('artist_')
+      if key.include?('input_artist_')
+        searched_artist = RSpotify::Artist.search(value).first
+        next unless searched_artist
+        artists << searched_artist.id
+      elsif key.include?('artist_')
         artists << value
       end
     end

--- a/app/views/spotify/recommendations.erb
+++ b/app/views/spotify/recommendations.erb
@@ -11,8 +11,17 @@
                 <% @top_artists.each_with_index do |artist, index| %>
                   <tr>
                     <td>
-                      <%= check_box_tag(:"#{artist.name}", "#{artist.id}", false, class: "is-checkradio", name: "artist_#{index}", id: "#{artist.id}") %>
+                      <%= check_box_tag(:"#{artist.name}", "#{artist.id}", false, class: "is-checkradio recommendation-input", name: "artist_#{index}", id: "#{artist.id}") %>
                       <%= label_tag(:"#{artist.id}", artist.name) %>
+                    </td>
+                  </tr>
+                <% end %>
+                <% 5.times do |i| %>
+                  <tr>
+                    <td>
+                      <%= check_box_tag(:"artist-submit-#{i}", "", false, class: "is-checkradio recommendation-input") %>
+                      <%= label_tag(:"artist-submit-#{i}", "") %>
+                      <%= text_field_tag("artist-submit-text-#{i}", nil, placeholder: "Artist name", class: "input is-pulled-right recommendation-input", style: "width: 80%") %>
                     </td>
                   </tr>
                 <% end %>
@@ -21,37 +30,38 @@
           </div>
           <div class="column">
             <%= label_tag(:acousticness, 'Acousticness') %>
-            <%= range_field_tag(:acousticness, :acousticness, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:acousticness, :acousticness, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:danceability, 'Danceability') %>
-            <%= range_field_tag(:danceability, :danceability, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:danceability, :danceability, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:energy, 'Energy') %>
-            <%= range_field_tag(:energy, :energy, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:energy, :energy, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:instrumentalness, 'Instrumentalness') %>
-            <%= range_field_tag(:instrumentalness, :instrumentalness, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:instrumentalness, :instrumentalness, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:liveness, 'Liveness') %>
-            <%= range_field_tag(:liveness, :liveness, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:liveness, :liveness, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:loudness, 'Loudness') %>
-            <%= range_field_tag(:loudness, :loudness, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:loudness, :loudness, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:popularity, 'Popularity') %>
-            <%= range_field_tag(:popularity, :popularity, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:popularity, :popularity, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:speechiness, 'Speechiness') %>
-            <%= range_field_tag(:speechiness, :speechiness, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:speechiness, :speechiness, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
 
             <%= label_tag(:valence, 'Valence') %>
-            <%= range_field_tag(:valence, :valence, in: 1..100, step: 1, class: 'slider is-fullwidth') %>
+            <%= range_field_tag(:valence, :valence, in: 1..100, step: 1, class: 'slider is-fullwidth recommendation-input') %>
           </div>
         </div>
       <% end %>
     </div>
     <div class="column">
       <h3 id="help-text" class="title is-3">Choose at least 1 artist to see recommendations</h3>
+      <h4 id="error-text" class="title is-3" hidden>If you entered an artist, make sure it is spelled correctly. If an artist cannot be found for a search, it will be ignored.</h4>
       <progress id="progress-bar" class="progress is-medium is-dark is-hidden" max="100">45%</progress>
       <table class="table" id="recommendation-table" hidden>
         <thead>


### PR DESCRIPTION
This adds boxes for users to input their own artists. These artists are
then searched on spotify and used for recommendations. As of right now
if no artist is found based on the searched string, it just ignores that
and gives the user an error message so they can hopefully sort it out.