### PR TITLE
Make files being saved unique

### DIFF
--- a/app/controllers/data_controller.rb
+++ b/app/controllers/data_controller.rb
@@ -18,7 +18,7 @@ class DataController < ApplicationController
     files.each do |file|
       JSON.parse(file.read) # Want this to raise if the files are not json parseable, we don't save the parsed output
 
-      file_path = ENV['FILE_UPLOAD_PATH'] + file.original_filename
+      file_path = ENV['FILE_UPLOAD_PATH'] + Time.now.to_i.to_s + file.original_filename
       unless File.file?(file_path)
         FileUtils.mv(file.tempfile, file_path)
         steaming_history = StreamingHistory.create!(


### PR DESCRIPTION
So it turns out everyone sends spotify files with the same name... That
will cause issues, so lets throw a timestamp on there to make sure we
aren't overwriting.