### PR TITLE
Lengthen retries for save streaming history

### DIFF
--- a/app/workers/save_streaming_history_track_job.rb
+++ b/app/workers/save_streaming_history_track_job.rb
@@ -2,6 +2,11 @@ require 'rspotify'
 
 class SaveStreamingHistoryTrackJob
   include Sidekiq::Worker
+  sidekiq_options retry: 20
+
+  sidekiq_retry_in do |count, exception|
+    1.hour.to_i * count
+  end
 
   def perform(json_listen, user_id)
     listen = JSON.parse(json_listen)


### PR DESCRIPTION
The default sidekiq retries do an exponential backoff. This is great
except the first handful of these retries all happen within a minute or
2. This absolutely hits the spotify rate limit, so lets just do this
over a few days by an extra hour each time. Hopefully this won't hit the
rate limit so hard.