### PR TITLE
Create a refresh users job

### DIFF
--- a/app/workers/refresh_users.rb
+++ b/app/workers/refresh_users.rb
@@ -1,0 +1,13 @@
+require 'rspotify'
+
+class RefreshUsers
+  include Sidekiq::Worker
+
+  def perform
+    SpotifyUser.all.each do |user|
+      id = user.spotify_user_hash['id']
+
+      user.update!(spotify_user_hash: RSpotify::User.find(id).to_hash)
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,7 @@
 scrobble_users:
   cron: "*/1 * * * *"
   class: "ScrobbleUsers"
+
+refresh_users:
+  cron: "* * */1 * *"
+  class: "RefreshUsers"


### PR DESCRIPTION
When users sign up I store their super basic data just to show them
their home page, but if they change their photo or get more followers, I
won't see that update. This job will run once a day to update users data
so it is sorta up to date.