### PR TITLE
Remove new job from schedule

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,7 +1,3 @@
 scrobble_users:
   cron: "*/1 * * * *"
   class: "ScrobbleUsers"
-
-refresh_users:
-  cron: "* * */1 * *"
-  class: "RefreshUsers"


### PR DESCRIPTION
Something happened that caused me to have to login again locally and I
am worried it is this job. I don't want to do that to all my users, so
lets stop this from running.