### PR TITLE
Add all time top tracks and artists to overview

### DIFF
--- a/app/assets/javascripts/statistics_overview.js
+++ b/app/assets/javascripts/statistics_overview.js
@@ -1,42 +1,67 @@
 //= require jquery3
 
 $(document).ready(function() {
-    $(".track-change").each(function() {
-        $(this).change(function() {
-            get_updated_stats();
-        });
-    });
+    get_top_artists();
+    get_top_tracks();
 });
 
-function get_updated_stats() {
+function get_top_artists() {
     $.ajax({
-        url: 'overview_data',
+        url: 'top_artists',
         type: 'post',
         dataType: 'json',
         data: dates(),
-        success: function(data) { update_results(data) },
+        success: function(data) { update_artists(data) },
+        error: function(error) {}
+    });
+}
+
+function get_top_tracks() {
+    $.ajax({
+        url: 'top_tracks',
+        type: 'post',
+        dataType: 'json',
+        data: dates(),
+        success: function(data) { update_tracks(data) },
         error: function(error) {}
     });
 }
 
 function dates() {
+    let today = new Date();
+
     return {
-        start_date: $('#start-date').val(),
-        end_date: $('#end-date').val()
+        start_date: '2000-01-01',
+        end_date: today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate()
     }
 }
 
-function update_results(data) {
-    let chart_area = $('.charts');
-    chart_area.empty();
+function update_artists(data) {
+    let tableBody = $('#artist-table tbody');
 
-    hide_error_text();
+    for (let record of data) {
+        let link = '/spotify/' + record[1]['id'] + '/artist';
+        let row = "<tr><td><a href=" + link + '>'  + truncate(record[0], 30) + '</a></td><td>' + record[1]['occurrences'] + '</td></tr>';
+
+        tableBody.append(row);
+    }
 }
 
-function show_error_text() {
-    $('.error-text').removeClass('is-hidden');
+function update_tracks(data) {
+    let tableBody = $('#track-table tbody');
+
+    for (let record of data) {
+        let link = '/spotify/' + record[1]['artist_id'] + '/artist';
+        let row = '<tr><td>'  + truncate(record[0], 30) + '</td><td><a href=' + link + '>'  + truncate(record[1]['artist'], 30) + '</a></td><td>' + record[1]['occurrences'] + '</td></tr>';
+
+        tableBody.append(row);
+    }
 }
 
-function hide_error_text() {
-    $('.error-text').addClass('is-hidden');
+function truncate(string, length) {
+    if (string.length < length || length < 1) {
+        return string
+    }
+
+    return string.substring(0, length-1) + '...';
 }

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -18,7 +18,7 @@ class StatisticsController < ApplicationController
   end
 
   def top_artists
-    return render json: {}, status: 400 if params['start_date'].empty? || params['end_date'].empty?
+    return render json: {}, status: 400 if params['end_date'].empty?
     top_artists = Statistics::Artists.top(user_id: current_user.id, start_date: params['start_date'], end_date: params['end_date'])
 
     render json: top_artists.first(10), status: 200
@@ -28,7 +28,7 @@ class StatisticsController < ApplicationController
   end
 
   def top_tracks
-    return render json: {}, status: 400 if params['start_date'].empty? || params['end_date'].empty?
+    return render json: {}, status: 400 if params['end_date'].empty?
     top_artists = Statistics::Tracks.top(user_id: current_user.id, start_date: params['start_date'], end_date: params['end_date'])
 
     render json: top_artists.first(10), status: 200

--- a/app/views/statistics/overview.erb
+++ b/app/views/statistics/overview.erb
@@ -19,14 +19,38 @@
             <br>
 
             <%= pie_chart Scrobble.where(user_id: current_user.id).group_by_day_of_week(:created_at, format: '%A').count, title: 'Listens by Day of the Week', width: "800px", height: "300px" %>
+            <br>
           </div>
-          <div id="error-text" class="error-text is-hidden">
-            <p class="title is-4">
-              You don't have enough data for this range.
-            </p>
-            <p class="title is-4">
-              Try uploading your streaming history <a href="/data/upload">here</a>
-            </p>
+          <div class="column is-narrow has-text-centered">
+            <div class="columns is-centered">
+              <div class="column is-narrow has-text-centered">
+                <p class="title is-3">Top Artists</p>
+                <table class="table" id="artist-table">
+                  <thead>
+                  <tr>
+                    <td><b>Artist</b></td>
+                    <td><b>Number of listens</b></td>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  </tbody>
+                </table>
+              </div>
+              <div class="column is-narrow has-text-centered">
+                <p class="title is-3">Top Tracks</p>
+                <table class="table" id="track-table">
+                  <thead>
+                  <tr>
+                    <td><b>Track</b></td>
+                    <td><b>Artist</b></td>
+                    <td><b>Number of listens</b></td>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
I am running out of ideas for this page despite having barely anything
since the API limits me, along with my own DB design. There are no
genres for tracks in spotify which makes it very hard to come up with
more charts worth showing. For now this will have to fill some space.