### PR TITLE
Add job to convert scrobbles to hears

### DIFF
--- a/app/workers/scrobble_to_hear.rb
+++ b/app/workers/scrobble_to_hear.rb
@@ -1,0 +1,18 @@
+require 'hears/hear_from_scrobble'
+
+class ScrobbleToHear
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_options retry: 20
+
+  sidekiq_throttle({ :threshold => { :limit => 1, :period => 1 } }) # 1 job per second max
+
+  sidekiq_retry_in do |count, exception|
+    1.hour.to_i * count
+  end
+
+  def perform(scrobble_id)
+    Hears::HearFromScrobble.new.call(scrobble: Scrobble.find(scrobble_id))
+  end
+end

--- a/app/workers/scrobbles_to_hears.rb
+++ b/app/workers/scrobbles_to_hears.rb
@@ -1,0 +1,9 @@
+class ScrobblesToHears
+  include Sidekiq::Worker
+
+  def perform
+    Scrobble.all.each do |scrobble|
+      ScrobbleToHear.perform_async(scrobble.id)
+    end
+  end
+end

--- a/lib/hears/find_or_create_album.rb
+++ b/lib/hears/find_or_create_album.rb
@@ -1,0 +1,21 @@
+require 'hears/find_or_create_artist'
+
+module Hears
+  class FindOrCreateAlbum
+    def call(album:)
+      if (return_album = Album.find_by(spotify_id: album.id))
+        return return_album
+      end
+
+      Album.create(
+          name: album.name,
+          spotify_id: album.id,
+          genres: album.genres,
+          popularity: album.popularity,
+          release_date: album.release_date,
+          total_tracks: album.total_tracks,
+          artists: album.artists.map { |artist| Hears::FindOrCreateArtist.new.call(artist: artist) }
+      )
+    end
+  end
+end

--- a/lib/hears/find_or_create_artist.rb
+++ b/lib/hears/find_or_create_artist.rb
@@ -1,0 +1,16 @@
+module Hears
+  class FindOrCreateArtist
+    def call(artist:)
+      if (return_artist = Artist.find_by(spotify_id: artist.id))
+        return return_artist
+      end
+
+      Artist.create(
+          name: artist.name,
+          spotify_id: artist.id,
+          genres: artist.genres,
+          popularity: artist.popularity
+      )
+    end
+  end
+end

--- a/lib/hears/find_or_create_track.rb
+++ b/lib/hears/find_or_create_track.rb
@@ -1,0 +1,24 @@
+require 'hears/find_or_create_artist'
+require 'hears/find_or_create_album'
+
+module Hears
+  class FindOrCreateTrack
+    def call(track:)
+      if (return_track = Track.find_by(spotify_id: track.id))
+        return return_track
+      end
+
+      Track.create(
+          name: track.name,
+          spotify_id: track.id,
+          duration_ms: track.duration_ms,
+          explicit: track.explicit,
+          popularity: track.popularity,
+          preview_url: track.preview_url,
+          track_number: track.track_number,
+          album: Hears::FindOrCreateAlbum.new.call(album: track.album),
+          artists: track.artists.map { |artist| Hears::FindOrCreateArtist.new.call(artist: artist) }
+      )
+    end
+  end
+end

--- a/lib/hears/hear_from_scrobble.rb
+++ b/lib/hears/hear_from_scrobble.rb
@@ -1,0 +1,10 @@
+require 'hears/find_or_create_track'
+
+module Hears
+  class HearFromScrobble
+    def call(scrobble:)
+      track = Hears::FindOrCreateTrack.new.call(track: RSpotify::Track.find(scrobble.track_id))
+      Hear.create(user_id: scrobble.user_id, track_id: track.id)
+    end
+  end
+end

--- a/lib/hears/track_hear.rb
+++ b/lib/hears/track_hear.rb
@@ -1,57 +1,10 @@
+require 'hears/find_or_create_track'
+
 module Hears
   class TrackHear
     def call(user_id:, track:)
-      db_track = find_or_create_track(track)
+      db_track = Hears::FindOrCreateTrack.new.call(track: track)
       Hear.create(user_id: user_id, track_id: db_track.id)
-    end
-
-    private
-
-    def find_or_create_track(track)
-      if (return_track = Track.find_by(spotify_id: track.id))
-        return return_track
-      end
-
-      Track.create(
-          name: track.name,
-          spotify_id: track.id,
-          duration_ms: track.duration_ms,
-          explicit: track.explicit,
-          popularity: track.popularity,
-          preview_url: track.preview_url,
-          track_number: track.track_number,
-          album: find_or_create_album(track.album),
-          artists: track.artists.map { |artist| find_or_create_artist(artist) }
-      )
-    end
-
-    def find_or_create_artist(artist)
-      if (return_artist = Artist.find_by(spotify_id: artist.id))
-        return return_artist
-      end
-
-      Artist.create(
-        name: artist.name,
-        spotify_id: artist.id,
-        genres: artist.genres,
-        popularity: artist.popularity
-      )
-    end
-
-    def find_or_create_album(album)
-      if (return_album = Album.find_by(spotify_id: album.id))
-        return return_album
-      end
-
-      Album.create(
-        name: album.name,
-        spotify_id: album.id,
-        genres: album.genres,
-        popularity: album.popularity,
-        release_date: album.release_date,
-        total_tracks: album.total_tracks,
-        artists: album.artists.map { |artist| find_or_create_artist(artist) }
-      )
     end
   end
 end


### PR DESCRIPTION
When called, `scrobbles_to_hears` will convert every scrobble in the DB
into hears, running 1 per second so as not to overload the Spotify API
and get me rate limited. This is going to make a whole ton of jobs.