### PR TITLE
Use hears on stats overview page

### DIFF
--- a/app/assets/javascripts/statistics_overview.js
+++ b/app/assets/javascripts/statistics_overview.js
@@ -1,8 +1,8 @@
 //= require jquery3
 
 $(document).ready(function() {
-    get_top_artists();
-    get_top_tracks();
+    // get_top_artists();
+    // get_top_tracks();
 });
 
 function get_top_artists() {

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -6,14 +6,6 @@ class StatisticsController < ApplicationController
   before_action :authenticate_user!
 
   def overview
-    top_hash = Scrobble.where(user_id: current_user).where.not(artist_name: 'Unknown Artist').top(:artist_name, 10)
-    top_total = top_hash.map {|h, k| k}.sum
-
-    top_artists = top_hash.map {|h, k| h }
-    top_artists << 'Unknown Artist'
-
-    other_total = Scrobble.where(user_id: current_user).where.not(artist_name: top_artists).top(:artist_name).map {|h, k| k}.sum
-    @top_vs_other_artists = {'Top Artists' => top_total, 'Other Artists' => other_total}
   end
 
   def overview_data

--- a/app/views/statistics/overview.erb
+++ b/app/views/statistics/overview.erb
@@ -14,47 +14,16 @@
     <div class="column is-narrow has-text-centered">
       <div class="columns is-centered">
         <div class="column is-narrow has-text-centered">
-          <p class="title is-2">Total Listens: <%= Scrobble.where(user_id: current_user).count %></p>
+          <p class="title is-2">Total Listens: <%= Hear.where(user_id: current_user).count %></p>
           <br>
           <div class="charts">
-            <%= column_chart Scrobble.where(user_id: current_user.id).group_by_month(:created_at, format: '%b %Y').count, title: 'Listens by Month', width: "800px", height: "300px" %>
+            <%= column_chart Hear.where(user_id: current_user.id).group_by_month(:created_at, format: '%b %Y').count, title: 'Listens by Month', width: "800px", height: "300px" %>
             <br>
 
-            <%= pie_chart Scrobble.where(user_id: current_user.id).group_by_day_of_week(:created_at, format: '%A').count, title: 'Listens by Day of the Week', width: "800px", height: "300px" %>
+            <%= pie_chart Hear.where(user_id: current_user.id).group_by_day_of_week(:created_at, format: '%A').count, title: 'Listens by Day of the Week', width: "800px", height: "300px" %>
             <br>
 
-            <%= pie_chart @top_vs_other_artists, title: 'Percentage of listens that are from top 10 artists', width: "800px", height: "300px" %>
-          </div>
-          <div class="column is-narrow has-text-centered">
-            <div class="columns is-centered">
-              <div class="column is-narrow has-text-centered">
-                <p class="title is-3">Top Artists</p>
-                <table class="table" id="artist-table">
-                  <thead>
-                  <tr>
-                    <td><b>Artist</b></td>
-                    <td><b>Number of listens</b></td>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  </tbody>
-                </table>
-              </div>
-              <div class="column is-narrow has-text-centered">
-                <p class="title is-3">Top Tracks</p>
-                <table class="table" id="track-table">
-                  <thead>
-                  <tr>
-                    <td><b>Track</b></td>
-                    <td><b>Artist</b></td>
-                    <td><b>Number of listens</b></td>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  </tbody>
-                </table>
-              </div>
-            </div>
+            <%#= pie_chart @top_vs_other_artists, title: 'Percentage of listens that are from top 10 artists', width: "800px", height: "300px" %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
We aren't tracking scrobbles anymore, so lets use the data we have. This
doesn't do the other stats pages, but we can deal with that later. Some
of the more complex queries are a complete nightmare right now, so the
more complicated charts will be more work.